### PR TITLE
fix: Throwing an error if user not logged in levelUp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,9 @@ export function getLeaderboardURL(questKey: string): URL {
  * Earns `xp` XP for the quest whose key is `questKey` for the current user.
  */
 export async function levelUp(questKey: string, xp: number): Promise<LevelUpResponse> {
+    if (!WA.player.isLogged) {
+        throw new Error("You must be logged to gain XP.");
+    }
     const url = new URL(`/api/quests/${questKey}/level-up`, questBaseUrl);
     const response = await fetch(url, {
         method: "POST",


### PR DESCRIPTION
If `levelUp` is called but the user is not logged, an exception will be thrown right away (instead of sending a request that will return an HTTP 401 anyway).